### PR TITLE
Add ABSPATH guard

### DIFF
--- a/better-elementor-globals/better-elementor-globals.php
+++ b/better-elementor-globals/better-elementor-globals.php
@@ -1,4 +1,5 @@
 <?php
+defined('ABSPATH') || exit;
 
 /**
  * Plugin Name: Better Elementor Globals


### PR DESCRIPTION
## Summary
- ensure `better-elementor-globals.php` exits when not loaded within WordPress

## Testing
- `php -l better-elementor-globals/better-elementor-globals.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684848cfdbd0832eb59bac80affc92c7