### PR TITLE
Implement activation renaming logic

### DIFF
--- a/better-elementor-globals/better-elementor-globals.php
+++ b/better-elementor-globals/better-elementor-globals.php
@@ -42,3 +42,29 @@ add_action('elementor/document/after_save', function ($document) {
     }
     return $document;
 }, 20);
+
+function beg_activate() {
+    $kit_id = get_option('elementor_active_kit');
+    if (empty($kit_id)) {
+        return;
+    }
+
+    $meta = get_post_meta($kit_id, '_elementor_page_settings', true);
+
+    if (true === isset($meta['custom_colors']) && false === empty($meta['custom_colors'])) {
+        foreach ($meta['custom_colors'] as $index => $custom_color) {
+            $meta['custom_colors'][$index]['_id'] = str_replace('-', '_', sanitize_title($custom_color['title']));
+        }
+    }
+
+    if (true === isset($meta['custom_typography']) && false === empty($meta['custom_typography'])) {
+        foreach ($meta['custom_typography'] as $index => $custom_typography) {
+            $meta['custom_typography'][$index]['_id'] = str_replace('-', '_', sanitize_title($custom_typography['title']));
+        }
+    }
+
+    update_post_meta($kit_id, '_elementor_page_settings', $meta);
+    wp_update_post(['ID' => $kit_id]);
+}
+
+register_activation_hook(__FILE__, 'beg_activate');


### PR DESCRIPTION
## Summary
- rename global color/typography IDs on plugin activation using `beg_activate`
- ensure current kit gets resaved when plugin activates

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68484c424808832eb31f963b18cff7ee