### PR TITLE
V1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ The same applies to global custom typographies. For example, '--e-global-typogra
 ## Changelog
 
 ### 1.1.0
-- TBD
+- Added an `ABSPATH` guard to prevent direct access.
+- Declared Elementor as a required plugin.
+- Introduced an activation hook that renames global IDs and updates the active kit.
+- Added a deactivation hook restoring the original IDs and posts.
+- Preserved global ID mappings across activations.
+- Updated the license text and "tested up to" information.
+- General code cleanup.
 
 ### 1.0.2
 - Renamed Plugin

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ The same applies to global custom typographies. For example, '--e-global-typogra
 
 ## Changelog
 
+### 1.1.0
+- TBD
+
 ### 1.0.2
 - Renamed Plugin
 

--- a/better-elementor-globals/better-elementor-globals.php
+++ b/better-elementor-globals/better-elementor-globals.php
@@ -6,7 +6,7 @@ defined('ABSPATH') || exit;
  * Requires Plugins: elementor
  * Description: Changes the variables names of custom global colors and custom global typographies to a more readable and reusable form.
  * Author: Patrick Heina
- * Version: 1.0.1
+ * Version: 1.1.0
  * Author URI: https://der-panda.de
  *
  * License: GPL v3

--- a/better-elementor-globals/better-elementor-globals.php
+++ b/better-elementor-globals/better-elementor-globals.php
@@ -1,4 +1,5 @@
 <?php
+defined('ABSPATH') || exit;
 
 /**
  * Plugin Name: Better Elementor Globals

--- a/better-elementor-globals/better-elementor-globals.php
+++ b/better-elementor-globals/better-elementor-globals.php
@@ -23,25 +23,92 @@ defined('ABSPATH') || exit;
  */
 
 
+/**
+ * Update all Elementor posts that contain old global IDs.
+ *
+ * @param array $map Array with 'colors' and 'typography' mappings old => new.
+ */
+function beg_update_elementor_posts(array $map)
+{
+    $posts = get_posts([
+        'post_type'      => 'any',
+        'posts_per_page' => -1,
+        'meta_query'     => [
+            [
+                'key'     => '_elementor_edit_mode',
+                'compare' => 'EXISTS',
+            ],
+        ],
+        'fields'         => 'ids',
+    ]);
+
+    foreach ($posts as $post_id) {
+        $data = get_post_meta($post_id, '_elementor_data', true);
+        if (empty($data)) {
+            continue;
+        }
+
+        $new_data = $data;
+        foreach ($map['colors'] ?? [] as $old => $new) {
+            $new_data = str_replace($old, $new, $new_data);
+        }
+        foreach ($map['typography'] ?? [] as $old => $new) {
+            $new_data = str_replace($old, $new, $new_data);
+        }
+
+        if ($new_data !== $data) {
+            update_post_meta($post_id, '_elementor_data', $new_data);
+        }
+    }
+}
+
+/**
+ * Sanitize global IDs of a kit and return an array of changed IDs.
+ *
+ * @param array $meta Kit meta.
+ * @param array $map  Mapping array passed by reference.
+ * @return array      Sanitized meta.
+ */
+function beg_sanitize_kit_meta(array $meta, array &$map)
+{
+    if (!empty($meta['custom_colors'])) {
+        foreach ($meta['custom_colors'] as $index => $custom_color) {
+            $new_id = str_replace('-', '_', sanitize_title($custom_color['title']));
+            if ($custom_color['_id'] !== $new_id) {
+                $map['colors'][$custom_color['_id']] = $new_id;
+                $meta['custom_colors'][$index]['_id'] = $new_id;
+            }
+        }
+    }
+
+    if (!empty($meta['custom_typography'])) {
+        foreach ($meta['custom_typography'] as $index => $custom_typography) {
+            $new_id = str_replace('-', '_', sanitize_title($custom_typography['title']));
+            if ($custom_typography['_id'] !== $new_id) {
+                $map['typography'][$custom_typography['_id']] = $new_id;
+                $meta['custom_typography'][$index]['_id'] = $new_id;
+            }
+        }
+    }
+
+    return $meta;
+}
+
 add_action('elementor/document/after_save', function ($document) {
     if ('Elementor\Core\Kits\Documents\Kit' === get_class($document)) {
-
         $meta = get_post_meta($document->get_main_id(), '_elementor_page_settings', true);
+        $map  = [];
+        $meta = beg_sanitize_kit_meta($meta, $map);
 
-        if (true === isset($meta['custom_colors']) && false === empty($meta['custom_colors'])) {
-            foreach ($meta['custom_colors'] as $index => $custom_color) {
-                $meta['custom_colors'][$index]['_id'] = str_replace('-', '_', sanitize_title($custom_color['title']));
-            }
+        if (!empty($map)) {
+            update_post_meta($document->get_main_id(), '_elementor_page_settings', $meta);
+            $stored_map = get_option('beg_id_map', []);
+            $merged_map = array_merge_recursive($stored_map, $map);
+            update_option('beg_id_map', $merged_map);
+            beg_update_elementor_posts($map);
         }
-
-        if (true === isset($meta['custom_typography']) && false === empty($meta['custom_typography'])) {
-            foreach ($meta['custom_typography'] as $index => $custom_typography) {
-                $meta['custom_typography'][$index]['_id'] = str_replace('-', '_', sanitize_title($custom_typography['title']));
-            }
-        }
-
-        update_post_meta($document->get_main_id(), '_elementor_page_settings', $meta);
     }
+
     return $document;
 }, 20);
 
@@ -52,21 +119,64 @@ function beg_activate() {
     }
 
     $meta = get_post_meta($kit_id, '_elementor_page_settings', true);
+    $map  = [];
+    $meta = beg_sanitize_kit_meta($meta, $map);
 
-    if (true === isset($meta['custom_colors']) && false === empty($meta['custom_colors'])) {
+    if (!empty($map)) {
+        update_post_meta($kit_id, '_elementor_page_settings', $meta);
+        update_option('beg_id_map', $map);
+        beg_update_elementor_posts($map);
+        wp_update_post(['ID' => $kit_id]);
+    }
+}
+
+function beg_deactivate() {
+    $kit_id = get_option('elementor_active_kit');
+    if (empty($kit_id)) {
+        return;
+    }
+
+    $map = get_option('beg_id_map', []);
+    if (empty($map)) {
+        return;
+    }
+
+    $meta = get_post_meta($kit_id, '_elementor_page_settings', true);
+
+    if (!empty($meta['custom_colors'])) {
         foreach ($meta['custom_colors'] as $index => $custom_color) {
-            $meta['custom_colors'][$index]['_id'] = str_replace('-', '_', sanitize_title($custom_color['title']));
+            foreach ($map['colors'] as $old => $new) {
+                if ($custom_color['_id'] === $new) {
+                    $meta['custom_colors'][$index]['_id'] = $old;
+                }
+            }
         }
     }
 
-    if (true === isset($meta['custom_typography']) && false === empty($meta['custom_typography'])) {
+    if (!empty($meta['custom_typography'])) {
         foreach ($meta['custom_typography'] as $index => $custom_typography) {
-            $meta['custom_typography'][$index]['_id'] = str_replace('-', '_', sanitize_title($custom_typography['title']));
+            foreach ($map['typography'] as $old => $new) {
+                if ($custom_typography['_id'] === $new) {
+                    $meta['custom_typography'][$index]['_id'] = $old;
+                }
+            }
         }
     }
 
     update_post_meta($kit_id, '_elementor_page_settings', $meta);
     wp_update_post(['ID' => $kit_id]);
+
+    $reverse = ['colors' => [], 'typography' => []];
+    foreach ($map as $type => $pairs) {
+        foreach ($pairs as $old => $new) {
+            $reverse[$type][$new] = $old;
+        }
+    }
+
+    beg_update_elementor_posts($reverse);
+
+    delete_option('beg_id_map');
 }
 
 register_activation_hook(__FILE__, 'beg_activate');
+register_deactivation_hook(__FILE__, 'beg_deactivate');

--- a/better-elementor-globals/better-elementor-globals.php
+++ b/better-elementor-globals/better-elementor-globals.php
@@ -15,11 +15,6 @@ defined('ABSPATH') || exit;
  * This plugin is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation,
  * either version 3 of the License, or any later version.
- *
- * Elementor is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
  */
 
 
@@ -28,8 +23,7 @@ defined('ABSPATH') || exit;
  *
  * @param array $map Array with 'colors' and 'typography' mappings old => new.
  */
-function beg_update_elementor_posts(array $map)
-{
+function beg_update_elementor_posts(array $map) {
     $posts = get_posts([
         'post_type'      => 'any',
         'posts_per_page' => -1,
@@ -69,8 +63,7 @@ function beg_update_elementor_posts(array $map)
  * @param array $map  Mapping array passed by reference.
  * @return array      Sanitized meta.
  */
-function beg_sanitize_kit_meta(array $meta, array &$map)
-{
+function beg_sanitize_kit_meta(array $meta, array &$map) {
     if (!empty($meta['custom_colors'])) {
         foreach ($meta['custom_colors'] as $index => $custom_color) {
             $new_id = str_replace('-', '_', sanitize_title($custom_color['title']));

--- a/better-elementor-globals/better-elementor-globals.php
+++ b/better-elementor-globals/better-elementor-globals.php
@@ -42,3 +42,29 @@ add_action('elementor/document/after_save', function ($document) {
     }
     return $document;
 }, 20);
+
+function beg_activate() {
+    $kit_id = get_option('elementor_active_kit');
+    if (empty($kit_id)) {
+        return;
+    }
+
+    $meta = get_post_meta($kit_id, '_elementor_page_settings', true);
+
+    if (true === isset($meta['custom_colors']) && false === empty($meta['custom_colors'])) {
+        foreach ($meta['custom_colors'] as $index => $custom_color) {
+            $meta['custom_colors'][$index]['_id'] = str_replace('-', '_', sanitize_title($custom_color['title']));
+        }
+    }
+
+    if (true === isset($meta['custom_typography']) && false === empty($meta['custom_typography'])) {
+        foreach ($meta['custom_typography'] as $index => $custom_typography) {
+            $meta['custom_typography'][$index]['_id'] = str_replace('-', '_', sanitize_title($custom_typography['title']));
+        }
+    }
+
+    update_post_meta($kit_id, '_elementor_page_settings', $meta);
+    wp_update_post(['ID' => $kit_id]);
+}
+
+register_activation_hook(__FILE__, 'beg_activate');

--- a/better-elementor-globals/better-elementor-globals.php
+++ b/better-elementor-globals/better-elementor-globals.php
@@ -2,6 +2,7 @@
 
 /**
  * Plugin Name: Better Elementor Globals
+ * Requires Plugins: elementor
  * Description: Changes the variables names of custom global colors and custom global typographies to a more readable and reusable form.
  * Author: Patrick Heina
  * Version: 1.0.1

--- a/better-elementor-globals/better-elementor-globals.php
+++ b/better-elementor-globals/better-elementor-globals.php
@@ -9,7 +9,7 @@ defined('ABSPATH') || exit;
  * Version: 1.1.0
  * Author URI: https://der-panda.de
  *
- * License: GPL v3
+ * License: GPL v3 or later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * This plugin is free software: you can redistribute it and/or modify it under the terms of the

--- a/better-elementor-globals/readme.txt
+++ b/better-elementor-globals/readme.txt
@@ -5,6 +5,7 @@ Requires at least: 5.9
 Tested up to: 6.2
 Stable tag: 1.0.1
 Requires PHP: 7.0
+Requires Plugins: elementor
 License: GPLv3 or Later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/better-elementor-globals/readme.txt
+++ b/better-elementor-globals/readme.txt
@@ -21,7 +21,13 @@ The same applies to global custom typographies. For example, '--e-global-typogra
 
 == Changelog ==
 = 1.1.0 =
-TBD
+* Added an ABSPATH guard to prevent direct access.
+* Declared Elementor as a required plugin.
+* Introduced an activation hook renaming global IDs and updating the active kit.
+* Added a deactivation hook restoring original IDs and posts.
+* Preserved global ID mappings across activations.
+* Updated the license text and "tested up to" information.
+* General code cleanup.
 = 1.0.2 =
 Renamed Plugins
 

--- a/better-elementor-globals/readme.txt
+++ b/better-elementor-globals/readme.txt
@@ -28,11 +28,12 @@ The same applies to global custom typographies. For example, '--e-global-typogra
 * Preserved global ID mappings across activations.
 * Updated the license text and "tested up to" information.
 * General code cleanup.
+
 = 1.0.2 =
-Renamed Plugins
+* Renamed Plugins
 
 = 1.0.1 =
-Bugfix: added missing str_replace
+* Bugfix: added missing str_replace
 
 = 1.0.0 =
-initial release
+* initial release

--- a/better-elementor-globals/readme.txt
+++ b/better-elementor-globals/readme.txt
@@ -2,7 +2,7 @@
 Contributors: pand0r
 Tags: elementor, elementor addons, elementor global settings, reusability, css variables, css classes, development
 Requires at least: 5.9
-Tested up to: 6.2
+Tested up to: 6.8.1
 Stable tag: 1.1.0
 Requires PHP: 7.0
 Requires Plugins: elementor

--- a/better-elementor-globals/readme.txt
+++ b/better-elementor-globals/readme.txt
@@ -3,7 +3,7 @@ Contributors: pand0r
 Tags: elementor, elementor addons, elementor global settings, reusability, css variables, css classes, development
 Requires at least: 5.9
 Tested up to: 6.2
-Stable tag: 1.0.1
+Stable tag: 1.1.0
 Requires PHP: 7.0
 Requires Plugins: elementor
 License: GPLv3 or Later
@@ -20,6 +20,8 @@ For example, if you have a custom global color called "Testimonial Container" it
 The same applies to global custom typographies. For example, '--e-global-typography-df1337-font-size' becomes '--e-global-typography-eye_catcher-font-size' if the typography is named 'Eye Catcher'.'--e-global-color-ad9560e' in '--e-global-color-testimonial-container'.
 
 == Changelog ==
+= 1.1.0 =
+TBD
 = 1.0.2 =
 Renamed Plugins
 


### PR DESCRIPTION
- Added an `ABSPATH` guard to prevent direct access.
- Declared Elementor as a required plugin.
- Introduced an activation hook that renames global IDs and updates the active kit.
- Added a deactivation hook restoring the original IDs and posts.
- Preserved global ID mappings across activations.
- Updated the license text and "tested up to" information.
- General code cleanup.
